### PR TITLE
build_config.h: add support for RISC-V architecture

### DIFF
--- a/source/build_config.h
+++ b/source/build_config.h
@@ -324,6 +324,16 @@
 #  define ARCH_CPU_ARM64 1
 #  define ARCH_CPU_64_BITS 1
 #  define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__riscv) && __riscv_xlen == 32
+#  define ARCH_CPU_RISCV_FAMILY 1
+#  define ARCH_CPU_RISCV32 1
+#  define ARCH_CPU_64_BITS 0
+#  define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__riscv) && __riscv_xlen == 64
+#  define ARCH_CPU_RISCV_FAMILY 1
+#  define ARCH_CPU_RISCV64 1
+#  define ARCH_CPU_64_BITS 1
+#  define ARCH_CPU_LITTLE_ENDIAN 1
 #elif defined(__pnacl__) || defined(__asmjs__) || defined(__wasm__)
 #  define ARCH_CPU_32_BITS 1
 #  define ARCH_CPU_LITTLE_ENDIAN 1
@@ -380,6 +390,9 @@
 #endif
 #if !defined(ARCH_CPU_PPC64_FAMILY)
 #  define ARCH_CPU_PPC64_FAMILY 0
+#endif
+#if !defined(ARCH_CPU_RISCV_FAMILY)
+#  define ARCH_CPU_RISCV_FAMILY 0
 #endif
 #if !defined(ARCH_CPU_S390_FAMILY)
 #  define ARCH_CPU_S390_FAMILY 0


### PR DESCRIPTION
This avoids a build error

    "Please add support for your platform in build_config.h"

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>